### PR TITLE
fix: wrong version in fxmanifest leading to error message

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game("gta5")
 lua54("yes")
 
 description("The default HUD resource for ESX-Legacy.")
-version("1.8.0")
+version("1.9.0")
 
 shared_scripts({
     "@es_extended/imports.lua",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5026eb6d-2e55-463d-a890-cc6c684c650e)
Version was still 1.8.0 in the fxmanifest, changed it to 1.9.0.