### PR TITLE
fix(client): fix health calculation for female players & status thread

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,9 +7,12 @@ function HUD:SetHudColor()
 end
 
 function HUD:Start(xPlayer)
+    while not ESX.PlayerLoaded do Wait(0) end
+
     if not xPlayer then
         xPlayer = ESX.GetPlayerData()
     end
+
     self:SetHudColor()
     self:SlowThick()
     self:FastThick()

--- a/client/player/status.lua
+++ b/client/player/status.lua
@@ -18,7 +18,7 @@ if not Config.Disable.Status then
             end
         end
 
-        values.healthBar = math.floor((GetEntityHealth(ESX.PlayerData.ped) - 100) / (GetEntityMaxHealth(ESX.PlayerData.ped) - 100) * 100)
+        values.healthBar = math.floor((GetEntityHealth(ESX.PlayerData.ped) - 100) / 100 * 100)
         values.armorBar = GetPedArmour(ESX.PlayerData.ped)
         values.drinkBar = thirst
         values.foodBar = hunger


### PR DESCRIPTION
### Summary
- Fixed an issue where player health percentage would show 133% for female players.
- Fixed an issue where the status thread would be started before the player has fully loaded, causing it to break out of the loop and never update again.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.